### PR TITLE
Reproduce firebase crash.

### DIFF
--- a/crashlytics/CrashlyticsExample/VisionTest.swift
+++ b/crashlytics/CrashlyticsExample/VisionTest.swift
@@ -7,11 +7,12 @@
 //
 
 import Foundation
-import Vision
+import CoreImage
 
 class VisionTest: NSObject {
   @objc public func doStuff() {
-
+    let context = CIContext()
+    let context2 = CIContext()
 
 
 //    VNImageRequestHandler(cgImage: CGImage(, options: [])


### PR DESCRIPTION
This reproduces the crash for me. Creating a single CIContext does not reproduce it, but creating two does.

The stack is slightly different from what I saw in my own app, but close enough that I'm pretty sure it's the same issue.

<img width="456" alt="Screen Shot 2021-02-03 at 10 05 09 AM" src="https://user-images.githubusercontent.com/227043/106765940-5910a780-6607-11eb-9eb3-f351257c5b43.png">
<img width="1043" alt="Screen Shot 2021-02-03 at 10 05 22 AM" src="https://user-images.githubusercontent.com/227043/106765945-5ada6b00-6607-11eb-8764-fe43220a6c7b.png">
